### PR TITLE
GH-37562: [Ruby] Add support for table.each_raw_record.to_a

### DIFF
--- a/ruby/red-arrow/ext/arrow/raw-records.cpp
+++ b/ruby/red-arrow/ext/arrow/raw-records.cpp
@@ -306,6 +306,10 @@ namespace red_arrow {
 
   VALUE
   record_batch_each_raw_record(VALUE rb_record_batch){
+    if (!rb_block_given_p()) {
+      return rb_funcall(rb_record_batch, rb_intern("to_enum"), 1, ID2SYM(rb_intern("each_raw_record")));
+    }
+
     auto garrow_record_batch = GARROW_RECORD_BATCH(RVAL2GOBJ(rb_record_batch));
     auto record_batch = garrow_record_batch_get_raw(garrow_record_batch).get();
 
@@ -321,6 +325,10 @@ namespace red_arrow {
 
   VALUE
   table_each_raw_record(VALUE rb_table) {
+    if (!rb_block_given_p()) {
+      return rb_funcall(rb_table, rb_intern("to_enum"), 1, ID2SYM(rb_intern("each_raw_record")));
+    }
+
     auto garrow_table = GARROW_TABLE(RVAL2GOBJ(rb_table));
     auto table = garrow_table_get_raw(garrow_table).get();
 

--- a/ruby/red-arrow/test/each-raw-record/test-struct-array.rb
+++ b/ruby/red-arrow/test/each-raw-record/test-struct-array.rb
@@ -652,7 +652,7 @@ module EachRawRecordStructArrayTests
   end
 end
 
-class RawRecordsRecordBatchStructArrayTest < Test::Unit::TestCase
+class EachRawRecordRecordBatchStructArrayTest < Test::Unit::TestCase
   include EachRawRecordStructArrayTests
 
   def build(type, records)
@@ -660,7 +660,7 @@ class RawRecordsRecordBatchStructArrayTest < Test::Unit::TestCase
   end
 end
 
-class RawRecordsTableStructArrayTest < Test::Unit::TestCase
+class EachRawRecordTableStructArrayTest < Test::Unit::TestCase
   include EachRawRecordStructArrayTests
 
   def build(type, records)

--- a/ruby/red-arrow/test/test-record-batch.rb
+++ b/ruby/red-arrow/test/test-record-batch.rb
@@ -178,5 +178,29 @@ class RecordBatchTest < Test::Unit::TestCase
                      @record_batch[[:c, "a", -1, 3..4]])
       end
     end
+
+    sub_test_case("#each_raw_record") do
+      def setup
+        schema = Arrow::Schema.new(visible: :boolean, count: :uint32)
+        @records = [
+          [true, 1],
+          [nil, 2],
+          [false, nil],
+        ]
+        @record_batch = Arrow::RecordBatch.new(schema, @records)
+      end
+
+      test("block") do
+        iterated_records = []
+        @record_batch.each_raw_record do |raw_record|
+          iterated_records << raw_record
+        end
+        assert_equal(@records, iterated_records)
+      end
+
+      test("without block") do
+        assert_equal(@records, @record_batch.each_raw_record.to_a)
+      end
+    end
   end
 end

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1427,4 +1427,22 @@ visible: false
                                 right_suffix: "_right"))
     end
   end
+
+  sub_test_case("#each_raw_record") do
+    setup do
+      @raw_records = @count_array.values.zip(@visible_array.values)
+    end
+
+    test("block") do
+      iterated_records = []
+      @table.each_raw_record do |raw_record|
+        iterated_records << raw_record
+      end
+      assert_equal(@raw_records, iterated_records)
+    end
+
+    test("without block") do
+      assert_equal(@raw_records, @table.each_raw_record.to_a)
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

This change aligns the behavior of `each_raw_record` with standard Ruby practices by returning an enumerator when no block is provided

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

- Made `Arrow::Table#each_raw_record` and `Arrow::RecordBatch#each_raw_record` return Enumerator when it was called without block.
- Added related tests
- Resolved warnings related to duplicate test classes which were caused by #37137

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes.

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->

Closes: https://github.com/apache/arrow/issues/37562